### PR TITLE
feat: add Inventory HUD module

### DIFF
--- a/src/modules/ModuleRegistry.cpp
+++ b/src/modules/ModuleRegistry.cpp
@@ -17,6 +17,7 @@
 #include "hud/playercoords.hpp"
 #include "hud/compass.hpp"
 #include "hud/armorhud.hpp"
+#include "hud/inventoryhud.hpp"
 #include "hud/potionhud.hpp"
 #include "player/timechanger.hpp"
 #include "player/autosprint.hpp"
@@ -101,6 +102,7 @@ void registerAllModules() {
     registry.emplace<PlayerCoordsModule>();
     registry.emplace<CompassModule>();
     registry.emplace<ArmorHudModule>();
+    registry.emplace<InventoryHudModule>();
     registry.emplace<PotionHudModule>();
     registry.emplace<TimeChangerModule>();
     registry.emplace<WorldTimeModule>();

--- a/src/modules/hud/huditems.cpp
+++ b/src/modules/hud/huditems.cpp
@@ -1,0 +1,494 @@
+#include "huditems.hpp"
+
+#include "core/memory/Hooks.hpp"
+
+#include <bedrocktools/memory/Signatures.hpp>
+#include <bedrocktools/sdk/input/MoveInput.hpp>
+#include <pl/ModMenu.hpp>
+#include <pl/memory/Vtable.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <mutex>
+#include <string_view>
+
+// entt resolves components by their (pretty-function derived) type name, so
+// this must be spelled exactly like the game's component and live at global
+// scope; wrapping it in a namespace would silently make tryGetComponent fail.
+struct ActorEquipmentComponent {
+    void* hand;
+    void* armorContainer;
+};
+static_assert(sizeof(ActorEquipmentComponent) == 0x10);
+
+namespace bedrocktools::huditems {
+namespace {
+
+namespace offsets = bedrocktools::sdk::offsets;
+
+constexpr std::size_t MaxContainerSlots = 64;
+constexpr float VanillaItemSize = 16.0f;
+constexpr const char* MinecraftLibrary = "libminecraftpe.so";
+
+// ItemRenderer::renderGuiItemNew "mode" argument: 1 is the regular icon,
+// 20 is the pass used by the dyed-leather opacity fix (see IconPainter).
+constexpr float RegularItemMode = 1.0f;
+constexpr float OpacityFixItemMode = 20.0f;
+constexpr float OpacityFixHudOpacity = 90.0f;
+
+// ScreenContext -> shader constant buffers -> HUD_OPACITY constant.
+constexpr std::size_t ScreenContextShaderConstants = 0x20;
+constexpr std::size_t ShaderConstantsHudOpacity = 0x150;
+constexpr std::size_t ShaderConstantData = 0x30;
+constexpr std::size_t ShaderConstantDirty = 0x29;
+
+struct RectangleArea {
+    float x0;
+    float x1;
+    float y0;
+    float y1;
+};
+
+struct Color {
+    float r;
+    float g;
+    float b;
+    float a;
+};
+
+class HashedString {
+public:
+    std::uint64_t hash;
+    std::string value;
+    mutable const HashedString* lastMatch;
+
+    explicit HashedString(const char* text)
+        : hash(computeHash(text ? std::string_view(text) : std::string_view())),
+          value(text ? text : ""),
+          lastMatch(nullptr) {}
+
+private:
+    static std::uint64_t computeHash(std::string_view text) {
+        if (text.empty()) return 0;
+        constexpr std::uint64_t offset = 0xCBF29CE484222325ULL;
+        constexpr std::uint64_t prime = 0x100000001B3ULL;
+        std::uint64_t result = offset;
+        for (char character : text) {
+            result = static_cast<std::uint64_t>(static_cast<unsigned char>(character)) ^ (prime * result);
+        }
+        return result;
+    }
+};
+
+using ActorGetOffhandSlotFn = const void* (*)(const void*);
+using HudCameraRendererFn = void (*)(void*, void*, void*, void*, int);
+using BaseActorRenderContextCtorFn = void (*)(void*, void*, void*, void*);
+using ItemStackBaseGetDamageValueFn = int (*)(void*);
+using ItemStackBaseGetRawNameIdFn = std::string (*)(void*);
+using ItemRendererRenderGuiItemNewFn = std::uint64_t (*)(
+    void*, void*, void*, unsigned int, unsigned char, std::uint64_t,
+    float, float, float, float, float);
+using MinecraftUIRenderContextFillRectangleFn = void (*)(
+    void*, const RectangleArea&, const Color&, float);
+
+ActorGetOffhandSlotFn actorGetOffhandSlot = nullptr;
+BaseActorRenderContextCtorFn baseActorRenderContextCtor = nullptr;
+ItemStackBaseGetDamageValueFn itemStackBaseGetDamageValue = nullptr;
+ItemStackBaseGetRawNameIdFn itemStackBaseGetRawNameId = nullptr;
+ItemRendererRenderGuiItemNewFn itemRendererRenderGuiItemNew = nullptr;
+bool functionsResolved = false;
+
+struct ListenerEntry {
+    RenderListener listener = nullptr;
+    void* user = nullptr;
+};
+
+// Fixed capacity so the render thread never allocates while copying the list.
+constexpr std::size_t MaxListeners = 8;
+std::mutex listenerMutex;
+std::array<ListenerEntry, MaxListeners> listeners{};
+std::size_t listenerCount = 0;
+HudCameraRendererFn hudCameraRendererOriginal = nullptr;
+bedrocktools::hooks::Handle hudRendererHook = nullptr;
+
+void** getVtable(void* object) {
+    return object ? *reinterpret_cast<void***>(object) : nullptr;
+}
+
+template <class T>
+T read(const void* object, std::size_t offset) {
+    return *reinterpret_cast<const T*>(static_cast<const std::byte*>(object) + offset);
+}
+
+void hudCameraRendererDetour(void* self, void* context, void* client, void* value, int pass) {
+    if (hudCameraRendererOriginal) hudCameraRendererOriginal(self, context, client, value, pass);
+    std::array<ListenerEntry, MaxListeners> snapshot{};
+    std::size_t count = 0;
+    {
+        std::lock_guard lock(listenerMutex);
+        snapshot = listeners;
+        count = listenerCount;
+    }
+    for (std::size_t i = 0; i < count; ++i) snapshot[i].listener(context, client, snapshot[i].user);
+}
+
+void installHook() {
+    if (hudRendererHook) return;
+    const std::uintptr_t hudRenderer = pl::memory::resolveVtableFunction(
+        "17HudCameraRenderer",
+        offsets::VTable::HudCameraRendererRender,
+        MinecraftLibrary);
+    if (!hudRenderer) return;
+    hudRendererHook = bedrocktools::hooks::install(
+        reinterpret_cast<void*>(hudRenderer),
+        reinterpret_cast<void*>(hudCameraRendererDetour),
+        reinterpret_cast<void**>(&hudCameraRendererOriginal));
+}
+
+void* getMinecraftGame(void* client) {
+    if (!client) return nullptr;
+    void** vtable = getVtable(client);
+    if (vtable && vtable[offsets::VTable::ClientInstanceGetMinecraftGame]) {
+        void* game = reinterpret_cast<void* (*)(void*)>(
+            vtable[offsets::VTable::ClientInstanceGetMinecraftGame])(client);
+        if (game) return game;
+    }
+    return read<void*>(client, offsets::ShulkerPreview::ClientInstanceMinecraftGame);
+}
+
+unsigned int getItemAnimationFrame(void* item, void* localPlayer, void* stack) {
+    if (!item || !localPlayer || !stack) return 0;
+    void** vtable = getVtable(item);
+    if (!vtable || !vtable[offsets::VTable::ItemGetAnimationFrameFor]) return 0;
+    using Fn = unsigned int (*)(void*, void*, int, void*, int);
+    return reinterpret_cast<Fn>(vtable[offsets::VTable::ItemGetAnimationFrameFor])(item, localPlayer, 0, stack, 1);
+}
+
+RectangleArea getFullClippingRectangle(void* context) {
+    RectangleArea result{};
+    void** vtable = getVtable(context);
+    if (!vtable || !vtable[offsets::VTable::MinecraftUIRenderContextGetFullClippingRectangle]) return result;
+    using Fn = RectangleArea (*)(void*);
+    return reinterpret_cast<Fn>(vtable[offsets::VTable::MinecraftUIRenderContextGetFullClippingRectangle])(context);
+}
+
+bool validRectangle(const RectangleArea& area) {
+    return std::isfinite(area.x0) && std::isfinite(area.x1) &&
+           std::isfinite(area.y0) && std::isfinite(area.y1) &&
+           area.x1 > area.x0 && area.y1 > area.y0;
+}
+
+void flushImages(void* context) {
+    void** vtable = getVtable(context);
+    if (!vtable || !vtable[offsets::VTable::MinecraftUIRenderContextFlushImages]) return;
+    using Fn = void (*)(void*, const Color&, float, const HashedString&);
+    static const HashedString material("ui_flush");
+    static constexpr Color color{1.0f, 1.0f, 1.0f, 1.0f};
+    reinterpret_cast<Fn>(vtable[offsets::VTable::MinecraftUIRenderContextFlushImages])(context, color, 1.0f, material);
+}
+
+void setHudOpacity(void* context, float opacity) {
+    if (!context) return;
+    void* screenContext = read<void*>(context, offsets::ShulkerPreview::MinecraftUIRenderContextScreenContext);
+    if (!screenContext) return;
+    auto* constantBuffers = read<std::byte*>(screenContext, ScreenContextShaderConstants);
+    if (!constantBuffers) return;
+    auto* shaderConstantBuffer = read<std::byte*>(constantBuffers, ShaderConstantsHudOpacity);
+    if (!shaderConstantBuffer) return;
+    auto* opacityPtr = read<float*>(shaderConstantBuffer, ShaderConstantData);
+    if (!opacityPtr) return;
+    if (*opacityPtr != opacity) {
+        *opacityPtr = opacity;
+        *reinterpret_cast<std::uint8_t*>(shaderConstantBuffer + ShaderConstantDirty) = 1;
+    }
+}
+
+void destroyBaseActorRenderContext(void* context) {
+    void** vtable = getVtable(context);
+    if (vtable && vtable[0]) reinterpret_cast<void (*)(void*)>(vtable[0])(context);
+}
+
+ActorEquipmentComponent* getEquipment(void* player) {
+    if (!player) return nullptr;
+    auto* context = reinterpret_cast<EntityContext*>(
+        reinterpret_cast<std::uintptr_t>(player) + offsets::Actor::mEntityContext);
+    return context->tryGetComponent<ActorEquipmentComponent>();
+}
+
+} // namespace
+
+void initialize() {
+    if (!actorGetOffhandSlot) {
+        actorGetOffhandSlot = reinterpret_cast<ActorGetOffhandSlotFn>(
+            bedrocktools::memory::resolve(bedrocktools::memory::SignatureId::ActorGetOffhandSlot));
+    }
+    if (!functionsResolved) {
+        baseActorRenderContextCtor = reinterpret_cast<BaseActorRenderContextCtorFn>(
+            bedrocktools::memory::resolve(bedrocktools::memory::SignatureId::BaseActorRenderContextCtor));
+        itemStackBaseGetDamageValue = reinterpret_cast<ItemStackBaseGetDamageValueFn>(
+            bedrocktools::memory::resolve(bedrocktools::memory::SignatureId::ItemStackBaseGetDamageValue));
+        itemStackBaseGetRawNameId = reinterpret_cast<ItemStackBaseGetRawNameIdFn>(
+            bedrocktools::memory::resolve(bedrocktools::memory::SignatureId::ItemStackBaseGetRawNameId));
+        itemRendererRenderGuiItemNew = reinterpret_cast<ItemRendererRenderGuiItemNewFn>(
+            bedrocktools::memory::resolve(bedrocktools::memory::SignatureId::ItemRendererRenderGuiItemNew));
+        functionsResolved = baseActorRenderContextCtor && itemRendererRenderGuiItemNew;
+    }
+    installHook();
+}
+
+bool addRenderListener(RenderListener listener, void* user) {
+    if (!listener) return false;
+    installHook();
+    std::lock_guard lock(listenerMutex);
+    for (std::size_t i = 0; i < listenerCount; ++i) {
+        if (listeners[i].listener == listener && listeners[i].user == user) return hudRendererHook != nullptr;
+    }
+    if (listenerCount >= MaxListeners) return false;
+    listeners[listenerCount++] = {listener, user};
+    return hudRendererHook != nullptr;
+}
+
+void removeRenderListener(RenderListener listener, void* user) {
+    std::lock_guard lock(listenerMutex);
+    for (std::size_t i = 0; i < listenerCount; ++i) {
+        if (listeners[i].listener != listener || listeners[i].user != user) continue;
+        for (std::size_t j = i + 1; j < listenerCount; ++j) listeners[j - 1] = listeners[j];
+        listeners[--listenerCount] = {};
+        return;
+    }
+}
+
+void* getLocalPlayer(void* client) {
+    void** vtable = getVtable(client);
+    if (!vtable || !vtable[offsets::VTable::ClientInstanceGetLocalPlayer]) return nullptr;
+    return reinterpret_cast<void* (*)(void*)>(vtable[offsets::VTable::ClientInstanceGetLocalPlayer])(client);
+}
+
+void* getCarriedItem(void* player) {
+    void** vtable = getVtable(player);
+    if (!vtable || !vtable[offsets::VTable::PlayerGetCarriedItem]) return nullptr;
+    return reinterpret_cast<void* (*)(void*)>(vtable[offsets::VTable::PlayerGetCarriedItem])(player);
+}
+
+ContainerSlots containerSlots(void* container) {
+    ContainerSlots slots;
+    if (!container) return slots;
+    const auto begin = read<std::uintptr_t>(container, offsets::Inventory::FillingContainerItems);
+    const auto end = read<std::uintptr_t>(container, offsets::Inventory::FillingContainerItems + sizeof(void*));
+    if (!begin || end < begin || begin % alignof(void*) != 0) return slots;
+    const auto span = end - begin;
+    if (span % offsets::Inventory::ItemStackSize != 0) return slots;
+    const auto count = span / offsets::Inventory::ItemStackSize;
+    if (count == 0 || count > MaxContainerSlots) return slots;
+    slots.begin = begin;
+    slots.count = static_cast<std::size_t>(count);
+    return slots;
+}
+
+ContainerSlots playerInventory(void* player) {
+    if (!player) return {};
+    void* proxy = read<void*>(player, offsets::Inventory::PlayerInventory);
+    if (!proxy) return {};
+    void* container = read<void*>(proxy, offsets::Inventory::PlayerInventoryContainer);
+    return containerSlots(container);
+}
+
+EquipmentStacks getEquipmentStacks(void* player) {
+    EquipmentStacks stacks;
+    if (!player) return stacks;
+    if (ActorEquipmentComponent* equipment = getEquipment(player)) {
+        const ContainerSlots armor = containerSlots(equipment->armorContainer);
+        if (armor.count >= 4) {
+            for (std::size_t i = 0; i < 4; ++i) stacks.armor[i] = armor.stack(i);
+        }
+        // The hand container holds both hands: slot 0 is the main hand and
+        // slot 1 the offhand. This is how the upstream ArmorHUD reads the
+        // offhand, and it works without any signature resolution, so it is
+        // tried first. The Actor accessor below stays as a fallback for game
+        // versions whose hand container does not expose this layout.
+        const ContainerSlots hands = containerSlots(equipment->hand);
+        if (hands.count >= 2) stacks.offhand = hands.stack(1);
+    }
+    if (!stacks.offhand && actorGetOffhandSlot) {
+        stacks.offhand = const_cast<void*>(actorGetOffhandSlot(player));
+    }
+    stacks.mainhand = getCarriedItem(player);
+    return stacks;
+}
+
+void* stackItem(void* stack) {
+    if (!stack) return nullptr;
+    void* counter = read<void*>(stack, offsets::ShulkerPreview::ItemStackBaseItem);
+    if (!counter) return nullptr;
+    return read<void*>(counter, offsets::ShulkerPreview::SharedCounterPointer);
+}
+
+std::uint8_t stackCount(void* stack) {
+    if (!stack) return 0;
+    return read<std::uint8_t>(stack, offsets::Inventory::ItemStackCount);
+}
+
+int stackDamage(void* stack) {
+    if (!stack || !itemStackBaseGetDamageValue) return 0;
+    return std::max(0, itemStackBaseGetDamageValue(stack));
+}
+
+int itemMaxDamage(void* item) {
+    void** vtable = getVtable(item);
+    if (!vtable || !vtable[offsets::VTable::ItemGetMaxDamage]) return 0;
+    return std::max(0, static_cast<int>(reinterpret_cast<short (*)(void*)>(vtable[offsets::VTable::ItemGetMaxDamage])(item)));
+}
+
+bool needsTextureOpacityPass(void* stack) {
+    if (!stack || !itemStackBaseGetRawNameId) return false;
+    const std::string name = itemStackBaseGetRawNameId(stack);
+    return name == "leather_helmet" ||
+           name == "leather_chestplate" ||
+           name == "leather_leggings" ||
+           name == "leather_boots" ||
+           name == "firework_star" ||
+           name == "leather_horse_armor";
+}
+
+HudMapping hudMapping(void* context) {
+    HudMapping mapping;
+    if (!context) return mapping;
+    const pl::modmenu::HudSurfaceSize surface = pl::modmenu::getHudSurfaceSize();
+    const RectangleArea full = getFullClippingRectangle(context);
+    if (surface.width <= 0.0f || surface.height <= 0.0f || !validRectangle(full)) return mapping;
+    mapping.originX = full.x0;
+    mapping.originY = full.y0;
+    mapping.scaleX = (full.x1 - full.x0) / surface.width;
+    mapping.scaleY = (full.y1 - full.y0) / surface.height;
+    mapping.valid = std::isfinite(mapping.scaleX) && std::isfinite(mapping.scaleY) &&
+                    mapping.scaleX > 0.0f && mapping.scaleY > 0.0f;
+    return mapping;
+}
+
+IconPainter::IconPainter(void* context, void* client, bool wantRender)
+    : mContext(context), mClient(client) {
+    if (!context || !client) return;
+    mPlayer = getLocalPlayer(client);
+    if (!wantRender || !mPlayer || !baseActorRenderContextCtor || !itemRendererRenderGuiItemNew) return;
+    mMapping = hudMapping(context);
+    if (!mMapping.valid) return;
+    void* screenContext = read<void*>(context, offsets::ShulkerPreview::MinecraftUIRenderContextScreenContext);
+    void* game = getMinecraftGame(client);
+    if (!screenContext || !game) return;
+    baseActorRenderContextCtor(mStorage, screenContext, client, game);
+    mConstructed = true;
+    mItemRenderer = *reinterpret_cast<void**>(mStorage + offsets::ShulkerPreview::BaseActorRenderContextItemRenderer);
+}
+
+IconPainter::~IconPainter() {
+    if (mInFixPass) endOpacityFixPass();
+    if (mConstructed) destroyBaseActorRenderContext(mStorage);
+    if (mDrewAny) flushImages(mContext);
+}
+
+bool IconPainter::paint(void* stack, void* item, float hudX, float hudY, float hudSize, float mode) {
+    if (!mItemRenderer || !stack || !item || hudSize <= 0.0f) return false;
+    const float x = mMapping.x(hudX);
+    const float y = mMapping.y(hudY);
+    const float width = hudSize * mMapping.scaleX;
+    const float height = hudSize * mMapping.scaleY;
+    const float iconSize = std::max(1.0f, std::min(width, height));
+    if (!std::isfinite(x) || !std::isfinite(y) || !std::isfinite(iconSize)) return false;
+    const unsigned int animationFrame = getItemAnimationFrame(item, mPlayer, stack);
+    itemRendererRenderGuiItemNew(
+        mItemRenderer,
+        mStorage,
+        stack,
+        animationFrame,
+        0,
+        0,
+        x,
+        y,
+        1.0f,
+        mode,
+        iconSize / VanillaItemSize);
+    return true;
+}
+
+bool IconPainter::draw(void* stack, void* item, float hudX, float hudY, float hudSize) {
+    if (!paint(stack, item, hudX, hudY, hudSize, RegularItemMode)) return false;
+    mDrewAny = true;
+    return true;
+}
+
+bool IconPainter::fillRect(float hudX, float hudY, float hudW, float hudH, std::uint32_t color) {
+    if (mInFixPass || !mContext || !mMapping.valid || hudW <= 0.0f || hudH <= 0.0f) return false;
+    void** vtable = getVtable(mContext);
+    if (!vtable || !vtable[offsets::VTable::MinecraftUIRenderContextFillRectangle]) return false;
+
+    // Fills go through the game's own MinecraftUIRenderContext, so the
+    // rectangle must use the same UI coordinates the icons are painted in.
+    const RectangleArea area{
+        mMapping.x(hudX),
+        mMapping.x(hudX + hudW),
+        mMapping.y(hudY),
+        mMapping.y(hudY + hudH)};
+    // Like flushImages()/drawText(), fillRectangle() blends with a separate
+    // opacity argument rather than Color::a: the caller packs the alpha into
+    // the top byte of `color` (see withOpacity), so it must be decoded and
+    // handed over as that trailing float. Leaving Color::a at 1.0 keeps the
+    // RGB untouched, so only the trailing opacity drives the transparency.
+    const float opacity = static_cast<float>((color >> 24) & 0xFF) / 255.0f;
+    const Color tint{
+        static_cast<float>((color >> 16) & 0xFF) / 255.0f,
+        static_cast<float>((color >> 8) & 0xFF) / 255.0f,
+        static_cast<float>(color & 0xFF) / 255.0f,
+        1.0f};
+    reinterpret_cast<MinecraftUIRenderContextFillRectangleFn>(
+        vtable[offsets::VTable::MinecraftUIRenderContextFillRectangle])(
+        mContext, area, tint, opacity);
+    // Like the icons, a queued fill only becomes visible when the image mesh
+    // is flushed, so it counts as work for the destructor's flush.
+    mDrewAny = true;
+    return true;
+}
+
+bool IconPainter::supportsOpacityFix() const {
+    return ready() && itemStackBaseGetRawNameId != nullptr;
+}
+
+void IconPainter::beginOpacityFixPass() {
+    if (!supportsOpacityFix() || mInFixPass) return;
+    setHudOpacity(mContext, OpacityFixHudOpacity);
+    mInFixPass = true;
+    mDrewFix = false;
+}
+
+bool IconPainter::drawOpacityFix(void* stack, void* item, float hudX, float hudY, float hudSize) {
+    if (!mInFixPass) return false;
+    if (!paint(stack, item, hudX, hudY, hudSize, OpacityFixItemMode)) return false;
+    mDrewFix = true;
+    return true;
+}
+
+void IconPainter::endOpacityFixPass() {
+    if (!mInFixPass) return;
+    if (mDrewFix) flushImages(mContext);
+    setHudOpacity(mContext, 1.0f);
+    mInFixPass = false;
+    mDrewFix = false;
+}
+
+std::uint32_t parseColor(const std::string& value, std::uint32_t fallback) {
+    if (value.empty()) return fallback;
+    const std::string hex = value[0] == '#' ? value.substr(1) : value;
+    try {
+        if (hex.size() == 6) return 0xFF000000u | static_cast<std::uint32_t>(std::stoul(hex, nullptr, 16));
+        if (hex.size() == 8) return static_cast<std::uint32_t>(std::stoul(hex, nullptr, 16));
+    } catch (...) {
+    }
+    return fallback;
+}
+
+std::uint32_t withOpacity(std::uint32_t color, float opacity) {
+    const auto alpha = static_cast<std::uint32_t>(std::clamp(opacity, 0.0f, 1.0f) * 255.0f);
+    return (alpha << 24) | (color & 0x00FFFFFFu);
+}
+
+} // namespace bedrocktools::huditems

--- a/src/modules/hud/huditems.hpp
+++ b/src/modules/hud/huditems.hpp
@@ -1,0 +1,151 @@
+#pragma once
+
+// Shared plumbing for the HUD modules that paint inventory items with the
+// game's own ItemRenderer (ArmorHUD, Hotbar Slots, Inventory HUD).
+//
+// Those modules only differ in *which* stacks they show and *where*. Everything
+// else lives here so it is written (and fixed for a new game version) once:
+//
+//   * the HudCameraRenderer::render hook that gives them a render pass,
+//   * walking Player -> Inventory::PlayerInventory -> proxy ->
+//     PlayerInventoryContainer -> FillingContainer::mItems in ItemStackSize
+//     steps, plus the armor container and the equipment hand container
+//     (offhand = slot 1, with the Actor::getOffhandSlot accessor as fallback),
+//   * constructing a BaseActorRenderContext to reach the ItemRenderer,
+//   * mapping launcher HUD units onto the MinecraftUIRenderContext,
+//   * ItemRenderer::renderGuiItemNew for one icon and the final flushImages.
+//
+// The header stays free of preloader / entt includes; the heavy lifting is in
+// huditems.cpp.
+
+#include <bedrocktools/sdk/Offsets.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace bedrocktools::huditems {
+
+// Resolves the ItemRenderer / ItemStackBase / BaseActorRenderContext
+// functions from the signature table. Idempotent; call it from onInit().
+void initialize();
+
+// One HudCameraRenderer::render hook shared by every item HUD module. The
+// listener runs on the render thread right after the vanilla HUD was drawn.
+using RenderListener = void (*)(void* context, void* client, void* user);
+bool addRenderListener(RenderListener listener, void* user);
+void removeRenderListener(RenderListener listener, void* user);
+
+// ---- Player / container access --------------------------------------------
+
+void* getLocalPlayer(void* client);
+void* getCarriedItem(void* player);
+
+// The contiguous ItemStack array of a FillingContainer.
+struct ContainerSlots {
+    std::uintptr_t begin = 0; // first ItemStack, 0 when the container is unusable
+    std::size_t count = 0;    // number of ItemStackSize-strided slots
+
+    // ItemStack of a slot, nullptr when the index is out of range.
+    void* stack(std::size_t index) const {
+        if (!begin || index >= count) return nullptr;
+        return reinterpret_cast<void*>(begin + index * sdk::offsets::Inventory::ItemStackSize);
+    }
+    explicit operator bool() const { return begin != 0 && count != 0; }
+};
+
+ContainerSlots containerSlots(void* container);
+
+// The player's own inventory: slots 0-8 are the hotbar, 9-35 the 9x3 grid of
+// the inventory screen.
+ContainerSlots playerInventory(void* player);
+
+struct EquipmentStacks {
+    void* armor[4] = {}; // helmet, chestplate, leggings, boots
+    void* offhand = nullptr;
+    void* mainhand = nullptr;
+};
+EquipmentStacks getEquipmentStacks(void* player);
+
+// ---- ItemStack inspection ---------------------------------------------------
+
+void* stackItem(void* stack);         // Item*, nullptr for an empty slot
+std::uint8_t stackCount(void* stack); // ItemStackBase::mCount
+int stackDamage(void* stack);         // ItemStackBase::getDamageValue, >= 0
+int itemMaxDamage(void* item);        // Item::getMaxDamage, 0 when unbreakable
+// Items whose icon needs the HUD-opacity pass (dyed leather etc., see
+// IconPainter::beginOpacityFixPass).
+bool needsTextureOpacityPass(void* stack);
+
+// ---- Drawing ----------------------------------------------------------------
+
+// Launcher HUD units (pl::modmenu::getHudSurfaceSize) -> UI render context
+// coordinates (MinecraftUIRenderContext::getFullClippingRectangle).
+struct HudMapping {
+    float originX = 0.0f;
+    float originY = 0.0f;
+    float scaleX = 0.0f;
+    float scaleY = 0.0f;
+    bool valid = false;
+
+    float x(float hudX) const { return originX + hudX * scaleX; }
+    float y(float hudY) const { return originY + hudY * scaleY; }
+};
+HudMapping hudMapping(void* context);
+
+// Scope that owns a BaseActorRenderContext for one HUD render pass. Icons are
+// batched into the UI image mesh and flushed when the painter goes away.
+class IconPainter {
+public:
+    // `wantRender == false` skips all render setup (the module still gets the
+    // player for bookkeeping); ready() is then false.
+    IconPainter(void* context, void* client, bool wantRender = true);
+    ~IconPainter();
+
+    IconPainter(const IconPainter&) = delete;
+    IconPainter& operator=(const IconPainter&) = delete;
+
+    bool ready() const { return mItemRenderer != nullptr; }
+    void* player() const { return mPlayer; }
+    const HudMapping& mapping() const { return mMapping; }
+
+    // Paints the icon of `stack` into the HUD-space square (hudX, hudY, hudSize).
+    bool draw(void* stack, void* item, float hudX, float hudY, float hudSize);
+
+    // Fills a HUD-space rectangle (hudX, hudY, hudW, hudH) with an ARGB color
+    // through the same UI context the icons use. Call it before draw() for a
+    // slot: fills are submitted first, so the icons of the same pass always
+    // land on top of them (slot backgrounds).
+    bool fillRect(float hudX, float hudY, float hudW, float hudH, std::uint32_t color);
+
+    // Dyed leather armor loses its tinted pixels when the HUD opacity shader
+    // constant is at its default; the fix is an extra pass at a high opacity
+    // with the renderer's "20" mode for just those stacks. Only stacks for
+    // which needsTextureOpacityPass() is true should be drawn in the pass.
+    bool supportsOpacityFix() const;
+    void beginOpacityFixPass();
+    bool drawOpacityFix(void* stack, void* item, float hudX, float hudY, float hudSize);
+    void endOpacityFixPass();
+
+private:
+    bool paint(void* stack, void* item, float hudX, float hudY, float hudSize, float mode);
+
+    void* mContext = nullptr;
+    void* mClient = nullptr;
+    void* mPlayer = nullptr;
+    HudMapping mMapping{};
+    alignas(16) std::byte mStorage[sdk::offsets::ShulkerPreview::BaseActorRenderContextStorageSize]{};
+    void* mItemRenderer = nullptr;
+    bool mConstructed = false;
+    bool mDrewAny = false;
+    bool mDrewFix = false;
+    bool mInFixPass = false;
+};
+
+// ---- Colors -----------------------------------------------------------------
+
+// "#RRGGBB" / "#AARRGGBB" -> ARGB, `fallback` when unparsable.
+std::uint32_t parseColor(const std::string& value, std::uint32_t fallback = 0xFFFFFFFFu);
+std::uint32_t withOpacity(std::uint32_t color, float opacity);
+
+} // namespace bedrocktools::huditems

--- a/src/modules/hud/inventoryhud.cpp
+++ b/src/modules/hud/inventoryhud.cpp
@@ -1,0 +1,454 @@
+#include "inventoryhud.hpp"
+
+#include "huditems.hpp"
+#include "modules/ModuleRegistry.hpp"
+
+#include <bedrocktools/events/EventBus.hpp>
+#include <pl/ModMenu.hpp>
+#include <pl/ModMenuConfig.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+namespace huditems = bedrocktools::huditems;
+namespace layout = bedrocktools::inventoryhud;
+namespace decor = bedrocktools::slotdecor;
+using layout::GridLayout;
+using decor::SlotRect;
+
+constexpr std::size_t GridSlotCount = InventoryHudModule::GridSlotCount;
+constexpr const char* GridElementId = "bedrocktools.inventoryhud.grid";
+
+void renderListener(void* context, void* client, void* user) {
+    auto* module = static_cast<InventoryHudModule*>(user);
+    if (module && module->enabled) module->renderNative(context, client);
+}
+
+} // namespace
+
+InventoryHudModule::InventoryHudModule()
+    : Module("Inventory HUD",
+             "Shows the items of your inventory grid on the HUD without opening the inventory.") {
+}
+
+InventoryHudModule::~InventoryHudModule() {
+    huditems::removeRenderListener(renderListener, this);
+}
+
+void InventoryHudModule::onInit() {
+    huditems::initialize();
+    huditems::addRenderListener(renderListener, this);
+
+    // The real inventory (and any other container UI) draws the same items at
+    // full size, so the HUD copy is hidden while one is open. The counter
+    // tracks nested opens the same way the runtime's keybind blocker does.
+    bedrocktools::events::bus().subscribe<bedrocktools::events::ScreenStateEvent>([this](auto& event) {
+        if (event.screen != bedrocktools::events::ScreenKind::Container) return;
+        if (event.phase == bedrocktools::events::ScreenPhase::Opened) {
+            m_containerDepth.fetch_add(1, std::memory_order_acq_rel);
+        } else {
+            int depth = m_containerDepth.load(std::memory_order_acquire);
+            while (depth > 0 &&
+                   !m_containerDepth.compare_exchange_weak(depth, depth - 1, std::memory_order_acq_rel)) {
+            }
+        }
+    });
+}
+
+void InventoryHudModule::onDisable() {
+    clearRuntime();
+    pl::modmenu::submitDrawCommands(moduleId, std::span<const pl::modmenu::DrawCommand>{});
+    pl::modmenu::submitHudEditorElements(moduleId, std::span<const pl::modmenu::HudEditorElement>{});
+}
+
+bool InventoryHudModule::hiddenByScreen() const {
+    return m_containerDepth.load(std::memory_order_acquire) > 0;
+}
+
+bedrocktools::inventoryhud::GridLayout InventoryHudModule::gridLayout() const {
+    layout::GridLayout grid;
+    grid.x = hudPosX;
+    grid.y = hudPosY;
+    grid.slotSize = m_slotSize;
+    grid.gap = m_slotGap;
+    grid.columns = layout::clampColumns(static_cast<std::size_t>(std::max(1, m_columns)));
+    return grid;
+}
+
+InventoryHudModule::ConfigSnapshot InventoryHudModule::snapshotConfig() const {
+    std::lock_guard lock(m_configMutex);
+    ConfigSnapshot config;
+    config.grid = gridLayout();
+    config.stackCount = m_showStackCount;
+    config.durability = m_showDurability;
+    config.hideInContainer = m_hideInContainer;
+    config.slotBackground = m_slotBackground;
+    config.slotBgColor = huditems::withOpacity(huditems::parseColor(m_slotBgColor, 0xFF000000u), m_slotBgOpacity);
+    config.countTextSize = m_countTextSize;
+    config.countColor = huditems::parseColor(m_countColor, 0xFFFFFFFFu);
+    config.gridSize = m_gridSize;
+    config.gridGap = m_gridGap;
+    config.snapThreshold = m_snapThreshold;
+    config.snapFlags =
+        (m_snapToGrid ? pl::modmenu::HudSnapGrid : pl::modmenu::HudSnapNone) |
+        (m_snapToElements ? pl::modmenu::HudSnapElements : pl::modmenu::HudSnapNone) |
+        (m_snapToScreenCenter ? pl::modmenu::HudSnapScreenCenter : pl::modmenu::HudSnapNone);
+    return config;
+}
+
+void InventoryHudModule::clearRuntime() {
+    for (auto& slot : m_grid) storeRuntime(slot, nullptr, nullptr, false);
+}
+
+// Publishes what the render thread saw for one slot to onFrame(); a null
+// `item` clears the slot.
+void InventoryHudModule::storeRuntime(SlotRuntime& runtime, void* stack, void* item, bool wantDurability) {
+    const bool hasItem = item != nullptr;
+    runtime.hasItem.store(hasItem, std::memory_order_release);
+    runtime.count.store(hasItem ? huditems::stackCount(stack) : 0, std::memory_order_release);
+    int damage = 0;
+    int maxDamage = 0;
+    if (hasItem && wantDurability) {
+        maxDamage = huditems::itemMaxDamage(item);
+        if (maxDamage > 0) damage = huditems::stackDamage(stack);
+    }
+    runtime.damage.store(damage, std::memory_order_release);
+    runtime.maxDamage.store(maxDamage, std::memory_order_release);
+}
+
+void InventoryHudModule::renderNative(void* context, void* client) {
+    const ConfigSnapshot config = snapshotConfig();
+    const bool hidden = config.hideInContainer && hiddenByScreen();
+
+    // Even while hidden the player is still needed to keep the overlay
+    // bookkeeping (counts / durability) current, so only the render setup
+    // is skipped.
+    huditems::IconPainter painter(context, client, !hidden);
+    void* localPlayer = painter.player();
+    if (!localPlayer) {
+        clearRuntime();
+        return;
+    }
+
+    const huditems::ContainerSlots inventory = huditems::playerInventory(localPlayer);
+    if (inventory.count <= layout::LastGridSlot) {
+        // Not the 36-slot player inventory we expect (e.g. mid-teleport
+        // rebuild); do not read outside the container.
+        clearRuntime();
+        return;
+    }
+
+    std::array<void*, GridSlotCount> stacks{};
+    std::array<void*, GridSlotCount> items{};
+    for (std::size_t i = 0; i < GridSlotCount; ++i) {
+        stacks[i] = inventory.stack(layout::containerSlot(i));
+        items[i] = huditems::stackItem(stacks[i]);
+        storeRuntime(m_grid[i], stacks[i], items[i], config.durability);
+    }
+
+    if (!painter.ready()) return;
+
+    // The slot cells are painted before the icons of the same pass, so each
+    // item stays on top of its background. Cells cover empty slots too,
+    // keeping the grid's shape steady while the inventory changes.
+    if (config.slotBackground) {
+        for (std::size_t i = 0; i < GridSlotCount; ++i) {
+            const SlotRect rect = layout::gridSlotRect(config.grid, i);
+            painter.fillRect(rect.x, rect.y, rect.size, rect.size, config.slotBgColor);
+        }
+    }
+
+    // Dyed leather armor (and a few other tinted items) need the HUD opacity
+    // fix pass first, otherwise their tinted pixels come out transparent.
+    if (painter.supportsOpacityFix()) {
+        painter.beginOpacityFixPass();
+        for (std::size_t i = 0; i < GridSlotCount; ++i) {
+            if (!items[i] || !huditems::needsTextureOpacityPass(stacks[i])) continue;
+            const SlotRect rect = layout::gridSlotRect(config.grid, i);
+            painter.drawOpacityFix(stacks[i], items[i], rect.x, rect.y, rect.size);
+        }
+        painter.endOpacityFixPass();
+    }
+
+    // Only occupied slots are submitted to the ItemRenderer; empty ones cost
+    // nothing.
+    for (std::size_t i = 0; i < GridSlotCount; ++i) {
+        if (!items[i]) continue;
+        const SlotRect rect = layout::gridSlotRect(config.grid, i);
+        painter.draw(stacks[i], items[i], rect.x, rect.y, rect.size);
+    }
+}
+
+void InventoryHudModule::onFrame() {
+    if (!enabled) return;
+
+    const ConfigSnapshot config = snapshotConfig();
+
+    // The editor box always covers the full grid so the element can be placed
+    // even while every slot is empty.
+    std::vector<pl::modmenu::HudEditorElement> elements;
+    {
+        pl::modmenu::HudEditorElement element;
+        element.elementId = GridElementId;
+        element.displayName = "Inventory Grid";
+        element.positionKeyX = "hudPosX";
+        element.positionKeyY = "hudPosY";
+        element.x = config.grid.x;
+        element.y = config.grid.y;
+        element.width = std::max(1.0f, layout::gridWidth(config.grid));
+        element.height = std::max(1.0f, layout::gridHeight(config.grid));
+        element.gridSize = config.gridSize;
+        element.snapThreshold = config.snapThreshold;
+        element.gridGap = config.gridGap;
+        element.snapFlags = config.snapFlags;
+        elements.push_back(std::move(element));
+    }
+    pl::modmenu::submitHudEditorElements(moduleId, elements);
+
+    std::vector<pl::modmenu::DrawCommand> commands;
+    const bool hidden = config.hideInContainer && hiddenByScreen();
+    if (!hidden && (config.stackCount || config.durability)) {
+        auto decorate = [&](const SlotRuntime& runtime, const SlotRect& rect) {
+            if (!runtime.hasItem.load(std::memory_order_acquire) || rect.size <= 0.0f) return;
+
+            const int maxDamage = runtime.maxDamage.load(std::memory_order_acquire);
+            const int damage = runtime.damage.load(std::memory_order_acquire);
+            if (config.durability && maxDamage > 0 && damage > 0) {
+                const float ratio = decor::durabilityRatio(damage, maxDamage);
+                const decor::DurabilityBar bar = decor::durabilityBar(rect, ratio);
+
+                pl::modmenu::DrawCommand background;
+                background.type = pl::modmenu::DrawCommandType::RectFilled;
+                background.x = bar.x;
+                background.y = bar.y;
+                background.w = bar.width;
+                background.h = bar.height;
+                background.color = 0xFF000000u;
+                commands.push_back(std::move(background));
+
+                if (bar.fillWidth > 0.0f) {
+                    pl::modmenu::DrawCommand fill;
+                    fill.type = pl::modmenu::DrawCommandType::RectFilled;
+                    fill.x = bar.x;
+                    fill.y = bar.y;
+                    fill.w = bar.fillWidth;
+                    fill.h = bar.fillHeight;
+                    fill.color = decor::durabilityColor(ratio);
+                    commands.push_back(std::move(fill));
+                }
+            }
+
+            const std::uint8_t count = runtime.count.load(std::memory_order_acquire);
+            if (config.stackCount && count > 1) {
+                const decor::TextAnchor anchor = decor::countTextAnchor(rect);
+                pl::modmenu::DrawCommand text;
+                text.type = pl::modmenu::DrawCommandType::Text;
+                text.x = anchor.x;
+                text.y = anchor.y;
+                text.w = -1.0f; // right-aligned at x
+                text.color = config.countColor;
+                text.size = config.countTextSize;
+                text.text = std::to_string(static_cast<unsigned>(count));
+                commands.push_back(std::move(text));
+            }
+        };
+
+        for (std::size_t i = 0; i < GridSlotCount; ++i) {
+            decorate(m_grid[i], layout::gridSlotRect(config.grid, i));
+        }
+    }
+    pl::modmenu::submitDrawCommands(moduleId, commands);
+}
+
+void InventoryHudModule::onMenuRegistered() {
+    using namespace pl::modmenu;
+    ConfigSchemaBuilder schema;
+    schema.defaultCategory("grid")
+        .category("grid", "Grid", "Shape and size of the inventory grid")
+        .category("details", "Details", "Extra information drawn on each slot")
+        .category("visibility", "Visibility", "When the inventory grid is shown")
+        .category("editor", "HUD Editor", "Placement and snapping while editing the HUD");
+
+    auto node = [](std::string key, std::string title, std::string category, ConfigControlTypeV2 type) {
+        ConfigNodeV2 value;
+        value.id = key;
+        value.key = std::move(key);
+        value.title = std::move(title);
+        value.category = std::move(category);
+        value.type = type;
+        return value;
+    };
+    auto section = [&](const char* id, const char* title, const char* category) {
+        auto value = node(id, title, category, ConfigControlTypeV2::Section);
+        value.key.clear();
+        schema.node(std::move(value));
+    };
+    auto slider = [&](const char* key, std::string title, const char* category,
+                      const char* sectionId, const char* min, const char* max,
+                      const char* unit = " px", const char* enabledKey = nullptr) {
+        auto value = node(key, std::move(title), category, ConfigControlTypeV2::SliderFloat);
+        value.section = sectionId;
+        value.minValue = min;
+        value.maxValue = max;
+        value.step = "1";
+        value.unit = unit;
+        if (enabledKey) value.visibleWhen = {{enabledKey, ConfigConditionOpV2::Truthy, {}}};
+        schema.node(std::move(value));
+    };
+
+    section("grid_shape", "Layout", "grid");
+    {
+        auto columns = node("m_columns", "Columns", "grid", ConfigControlTypeV2::SliderInt);
+        columns.section = "grid_shape";
+        columns.description = "9 columns match the inventory screen; fewer columns wrap the 27 slots into more rows.";
+        columns.minValue = std::to_string(layout::MinColumns);
+        columns.maxValue = std::to_string(layout::MaxColumns);
+        columns.step = "1";
+        schema.node(std::move(columns));
+    }
+    slider("m_slotSize", "Slot Size", "grid", "grid_shape", "8", "100");
+    slider("m_slotGap", "Gap Between Slots", "grid", "grid_shape", "0", "50");
+    section("activation", "Shortcut", "grid");
+    {
+        auto toggleKey = node("keybind", "Toggle Keybind", "grid", ConfigControlTypeV2::Keybind);
+        toggleKey.section = "activation";
+        schema.node(std::move(toggleKey));
+    }
+
+    section("slot_details", "Slot Details", "details");
+    {
+        auto features = node("slot_features", "Show", "details", ConfigControlTypeV2::ToggleGroup);
+        features.key.clear();
+        features.section = "slot_details";
+        features.description = "Armor and offhand now live in the separate Armor module.";
+        features.choiceStyle = ConfigChoiceStyleV2::Checklist;
+        features.options = {
+            {"count", "Stack Count", {}, "m_showStackCount"},
+            {"durability", "Durability Bar", {}, "m_showDurability"}
+        };
+        schema.node(std::move(features));
+    }
+    section("count_text", "Number Text", "details");
+    slider("m_countTextSize", "Text Size", "details", "count_text", "6", "40");
+    {
+        auto color = node("m_countColor", "Text Color", "details", ConfigControlTypeV2::Color);
+        color.section = "count_text";
+        color.defaultValue = "#FFFFFF";
+        color.description = "Used for stack counts.";
+        schema.node(std::move(color));
+    }
+    section("slot_background", "Slot Background", "details");
+    {
+        auto toggle = node("m_slotBackground", "Slot Background", "details", ConfigControlTypeV2::Toggle);
+        toggle.section = "slot_background";
+        toggle.description = "Draws a cell behind every slot of the grid, including empty ones, so the grid reads like the inventory screen.";
+        schema.node(std::move(toggle));
+
+        auto opacity = node("m_slotBgOpacity", "Background Opacity", "details", ConfigControlTypeV2::SliderFloat);
+        opacity.section = "slot_background";
+        opacity.minValue = "0.05";
+        opacity.maxValue = "1";
+        opacity.step = "0.05";
+        opacity.visibleWhen = {{"m_slotBackground", ConfigConditionOpV2::Truthy, {}}};
+        schema.node(std::move(opacity));
+
+        auto color = node("m_slotBgColor", "Background Color", "details", ConfigControlTypeV2::Color);
+        color.section = "slot_background";
+        color.defaultValue = "#000000";
+        color.visibleWhen = {{"m_slotBackground", ConfigConditionOpV2::Truthy, {}}};
+        color.description = "Color of the cells behind the slots; the opacity slider above sets how strongly they show.";
+        schema.node(std::move(color));
+    }
+
+    section("auto_hide", "Automatic Hiding", "visibility");
+    {
+        auto hide = node("m_hideInContainer", "Hide While Inventory Is Open", "visibility", ConfigControlTypeV2::Toggle);
+        hide.section = "auto_hide";
+        hide.description = "Hides the grid while the inventory, a chest or any other container screen is open.";
+        schema.node(std::move(hide));
+    }
+
+    auto help = node("editor_help", "Armor Moved To Its Own Module", "editor", ConfigControlTypeV2::Info);
+    help.key.clear();
+    help.description = "This module owns a single HUD Editor element: Inventory Grid. Your armor and offhand are drawn by the separate Armor module, which has its own toggle, element and settings.";
+    schema.node(std::move(help));
+    section("snapping", "Snapping", "editor");
+    {
+        auto snapping = node("snap_targets", "Snap To", "editor", ConfigControlTypeV2::ToggleGroup);
+        snapping.key.clear();
+        snapping.section = "snapping";
+        snapping.choiceStyle = ConfigChoiceStyleV2::Chips;
+        snapping.options = {
+            {"grid", "Grid", {}, "m_snapToGrid"},
+            {"items", "Other Elements", {}, "m_snapToElements"},
+            {"center", "Screen Center", {}, "m_snapToScreenCenter"}
+        };
+        schema.node(std::move(snapping));
+    }
+    slider("m_gridSize", "Grid Size", "editor", "snapping", "1", "100", " px", "m_snapToGrid");
+    slider("m_gridGap", "Gap Between Elements", "editor", "snapping", "0", "100", " px", "m_snapToElements");
+    slider("m_snapThreshold", "Snap Distance", "editor", "snapping", "1", "100");
+
+    pl::modmenu::setConfigSchemaJson(moduleId, schema.toJson());
+}
+
+void InventoryHudModule::loadConfig(const nlohmann::json& j) {
+    Module::loadConfig(j);
+    std::lock_guard lock(m_configMutex);
+
+    if (j.contains("hudPosX")) hudPosX = std::clamp(j["hudPosX"].get<float>(), 0.0f, 4000.0f);
+    if (j.contains("hudPosY")) hudPosY = std::clamp(j["hudPosY"].get<float>(), 0.0f, 4000.0f);
+    if (j.contains("m_columns")) {
+        m_columns = std::clamp(j["m_columns"].get<int>(),
+                               static_cast<int>(layout::MinColumns), static_cast<int>(layout::MaxColumns));
+    }
+    if (j.contains("m_slotSize")) m_slotSize = std::clamp(j["m_slotSize"].get<float>(), 8.0f, 100.0f);
+    if (j.contains("m_slotGap")) m_slotGap = std::clamp(j["m_slotGap"].get<float>(), 0.0f, 50.0f);
+    if (j.contains("m_showStackCount")) m_showStackCount = j["m_showStackCount"].get<bool>();
+    if (j.contains("m_showDurability")) m_showDurability = j["m_showDurability"].get<bool>();
+    if (j.contains("m_hideInContainer")) m_hideInContainer = j["m_hideInContainer"].get<bool>();
+    if (j.contains("m_slotBackground")) m_slotBackground = j["m_slotBackground"].get<bool>();
+    if (j.contains("m_slotBgOpacity")) m_slotBgOpacity = std::clamp(j["m_slotBgOpacity"].get<float>(), 0.05f, 1.0f);
+    if (j.contains("m_slotBgColor")) m_slotBgColor = j["m_slotBgColor"].get<std::string>();
+    if (j.contains("m_countTextSize")) m_countTextSize = std::clamp(j["m_countTextSize"].get<float>(), 6.0f, 40.0f);
+    if (j.contains("m_countColor")) m_countColor = j["m_countColor"].get<std::string>();
+    if (j.contains("m_gridSize")) m_gridSize = std::clamp(j["m_gridSize"].get<float>(), 1.0f, 100.0f);
+    if (j.contains("m_gridGap")) m_gridGap = std::clamp(j["m_gridGap"].get<float>(), 0.0f, 100.0f);
+    if (j.contains("m_snapThreshold")) m_snapThreshold = std::clamp(j["m_snapThreshold"].get<float>(), 1.0f, 100.0f);
+    if (j.contains("m_snapToGrid")) m_snapToGrid = j["m_snapToGrid"].get<bool>();
+    if (j.contains("m_snapToElements")) m_snapToElements = j["m_snapToElements"].get<bool>();
+    if (j.contains("m_snapToScreenCenter")) m_snapToScreenCenter = j["m_snapToScreenCenter"].get<bool>();
+}
+
+void InventoryHudModule::saveConfig(nlohmann::json& j) {
+    Module::saveConfig(j);
+    std::lock_guard lock(m_configMutex);
+
+    j["hudPosX"] = hudPosX;
+    j["hudPosY"] = hudPosY;
+    j["m_columns"] = m_columns;
+    j["m_slotSize"] = m_slotSize;
+    j["m_slotGap"] = m_slotGap;
+    j["m_showStackCount"] = m_showStackCount;
+    j["m_showDurability"] = m_showDurability;
+    j["m_hideInContainer"] = m_hideInContainer;
+    j["m_slotBackground"] = m_slotBackground;
+    j["m_slotBgOpacity"] = m_slotBgOpacity;
+    j["m_slotBgColor"] = m_slotBgColor;
+    j["m_countTextSize"] = m_countTextSize;
+    j["m_countColor"] = m_countColor;
+    j["m_gridSize"] = m_gridSize;
+    j["m_gridGap"] = m_gridGap;
+    j["m_snapThreshold"] = m_snapThreshold;
+    j["m_snapToGrid"] = m_snapToGrid;
+    j["m_snapToElements"] = m_snapToElements;
+    j["m_snapToScreenCenter"] = m_snapToScreenCenter;
+}

--- a/src/modules/hud/inventoryhud.hpp
+++ b/src/modules/hud/inventoryhud.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "../Module.hpp"
+#include "inventoryhud_layout.hpp"
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <string>
+
+// Shows the player's main inventory (container slots 9-35, the 9x3 grid of
+// the inventory screen) as item icons on the HUD, so the contents are visible
+// without opening the inventory.
+//
+// Armor and the offhand are handled by the separate Armor module: this module
+// owns nothing but the inventory grid.
+//
+// It shares its plumbing with the Armor module and Hotbar Slots (see
+// huditems.hpp): the stacks come straight from the player's FillingContainer
+// and the icons are painted by the game's ItemRenderer from the
+// HudCameraRenderer hook. Stack counts and durability bars use launcher
+// overlay draw commands, like the other HUD modules' text.
+class InventoryHudModule final : public Module {
+public:
+    static constexpr std::size_t GridSlotCount = bedrocktools::inventoryhud::GridSlotCount;
+
+    InventoryHudModule();
+    ~InventoryHudModule() override;
+
+    void onInit() override;
+    void onDisable() override;
+    void onFrame() override;
+    void onMenuRegistered() override;
+    void loadConfig(const nlohmann::json& j) override;
+    void saveConfig(nlohmann::json& j) override;
+
+    // Called from the shared HudCameraRenderer detour.
+    void renderNative(void* context, void* client);
+
+    // Icons are hidden while the real inventory / container screen is open;
+    // the counter mirrors the ScreenStateEvent container depth.
+    bool hiddenByScreen() const;
+
+private:
+    struct SlotRuntime {
+        std::atomic_bool hasItem{false};
+        std::atomic<std::uint8_t> count{0};
+        std::atomic_int damage{0};
+        std::atomic_int maxDamage{0};
+    };
+
+    struct ConfigSnapshot {
+        bedrocktools::inventoryhud::GridLayout grid{};
+        bool stackCount = true;
+        bool durability = true;
+        bool hideInContainer = true;
+        bool slotBackground = true;
+        std::uint32_t slotBgColor = 0x73000000u; // "#000000" at 45%
+        float countTextSize = 12.0f;
+        std::uint32_t countColor = 0xFFFFFFFFu;
+        float gridSize = 16.0f;
+        float gridGap = 4.0f;
+        float snapThreshold = 12.0f;
+        std::uint32_t snapFlags = 0;
+    };
+
+    ConfigSnapshot snapshotConfig() const;
+    // Expects m_configMutex to be held.
+    bedrocktools::inventoryhud::GridLayout gridLayout() const;
+    void clearRuntime();
+    void storeRuntime(SlotRuntime& runtime, void* stack, void* item, bool wantDurability);
+
+    mutable std::mutex m_configMutex;
+    std::array<SlotRuntime, GridSlotCount> m_grid;
+    std::atomic_int m_containerDepth{0};
+
+    float hudPosX = 24.0f;
+    float hudPosY = 200.0f;
+    int m_columns = static_cast<int>(bedrocktools::inventoryhud::DefaultColumns);
+    float m_slotSize = 32.0f;
+    float m_slotGap = 4.0f;
+    bool m_showStackCount = true;
+    bool m_showDurability = true;
+    bool m_hideInContainer = true;
+    bool m_slotBackground = true;
+    float m_slotBgOpacity = 0.45f;
+    std::string m_slotBgColor = "#000000";
+    float m_countTextSize = 12.0f;
+    std::string m_countColor = "#FFFFFF";
+
+    float m_gridSize = 16.0f;
+    float m_gridGap = 4.0f;
+    float m_snapThreshold = 12.0f;
+    bool m_snapToGrid = true;
+    bool m_snapToElements = true;
+    bool m_snapToScreenCenter = true;
+};

--- a/src/modules/hud/inventoryhud_layout.hpp
+++ b/src/modules/hud/inventoryhud_layout.hpp
@@ -1,0 +1,91 @@
+#pragma once
+
+// Pure layout math for the Inventory HUD module.
+//
+// The module paints the 27 slots of the player's main inventory (container
+// slots 9-35, the 9x3 grid of the inventory screen) as item icons on the HUD.
+// Armor and the offhand are NOT part of this module any more: they live in the
+// separate Armor module (armorhud_layout.hpp) with their own HUD element and
+// settings. Keeping the math header-only and free of Minecraft types lets the
+// host unit tests cover it.
+
+#include "slotdecor_layout.hpp"
+
+#include <algorithm>
+#include <cstddef>
+
+namespace bedrocktools::inventoryhud {
+
+using slotdecor::SlotRect;
+
+inline constexpr std::size_t HotbarSlotCount = 9;
+inline constexpr std::size_t FirstGridSlot = HotbarSlotCount; // container slot 9
+inline constexpr std::size_t GridSlotCount = 27;              // container slots 9-35
+inline constexpr std::size_t LastGridSlot = FirstGridSlot + GridSlotCount - 1;
+inline constexpr std::size_t MinColumns = 1;
+inline constexpr std::size_t MaxColumns = GridSlotCount;
+inline constexpr std::size_t DefaultColumns = 9;
+
+// Anchor and shape of the inventory grid element.
+struct GridLayout {
+    float x = 0.0f;                   // anchor (top-left of the grid), HUD units
+    float y = 0.0f;
+    float slotSize = 32.0f;           // width and height of one slot
+    float gap = 4.0f;                 // space between two slots
+    std::size_t columns = DefaultColumns;
+};
+
+inline std::size_t clampColumns(std::size_t columns) {
+    return std::clamp(columns, MinColumns, MaxColumns);
+}
+
+// Rows needed to show every grid slot with the configured column count.
+inline std::size_t rowCount(const GridLayout& layout) {
+    const std::size_t columns = clampColumns(layout.columns);
+    return (GridSlotCount + columns - 1) / columns;
+}
+
+// Container slot index of a grid cell (0-26 -> 9-35).
+inline std::size_t containerSlot(std::size_t gridIndex) {
+    if (gridIndex >= GridSlotCount) gridIndex = GridSlotCount - 1;
+    return FirstGridSlot + gridIndex;
+}
+
+// Position of one grid cell. Out-of-range indices are clamped so callers can
+// never produce a rectangle outside the element.
+inline SlotRect gridSlotRect(const GridLayout& layout, std::size_t gridIndex) {
+    if (gridIndex >= GridSlotCount) gridIndex = GridSlotCount - 1;
+    const std::size_t columns = clampColumns(layout.columns);
+    const float step = layout.slotSize + layout.gap;
+    SlotRect rect;
+    rect.size = layout.slotSize;
+    rect.x = layout.x + step * static_cast<float>(gridIndex % columns);
+    rect.y = layout.y + step * static_cast<float>(gridIndex / columns);
+    return rect;
+}
+
+inline float gridWidth(const GridLayout& layout) {
+    const std::size_t columns = clampColumns(layout.columns);
+    return layout.slotSize * static_cast<float>(columns) + layout.gap * static_cast<float>(columns - 1);
+}
+
+inline float gridHeight(const GridLayout& layout) {
+    const std::size_t rows = rowCount(layout);
+    return layout.slotSize * static_cast<float>(rows) + layout.gap * static_cast<float>(rows - 1);
+}
+
+// ---- Per-slot decorations ---------------------------------------------------
+//
+// Shared with the Armor module; re-exported here so existing callers and tests
+// keep working.
+
+using slotdecor::DurabilityBar;
+using slotdecor::TextAnchor;
+using slotdecor::countTextAnchor;
+using slotdecor::durabilityBar;
+using slotdecor::durabilityColor;
+using slotdecor::durabilityRatio;
+using slotdecor::durabilityText;
+using slotdecor::remainingDurability;
+
+} // namespace bedrocktools::inventoryhud

--- a/src/modules/hud/slotdecor_layout.hpp
+++ b/src/modules/hud/slotdecor_layout.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+// Decorations every item-slot HUD module draws on top of an icon: the vanilla
+// durability bar, the remaining/maximum durability text and the anchor of the
+// stack count in a slot's bottom-right corner.
+//
+// Inventory HUD and the Armor module both paint square item slots, so this
+// math is shared instead of duplicated. It stays header-only and free of
+// Minecraft types so the host unit tests can cover it.
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+
+namespace bedrocktools::slotdecor {
+
+struct SlotRect {
+    float x = 0.0f;
+    float y = 0.0f;
+    float size = 0.0f;
+};
+
+// Vanilla draws the durability bar 2px from the left, 13px from the top, 13px
+// wide and 2px tall (with a 1px fill) inside a 16px icon; this scales those
+// proportions to the slot size.
+struct DurabilityBar {
+    float x = 0.0f;
+    float y = 0.0f;
+    float width = 0.0f;
+    float height = 0.0f;
+    float fillWidth = 0.0f;
+    float fillHeight = 0.0f;
+};
+
+inline int remainingDurability(int damage, int maxDamage) {
+    if (maxDamage <= 0) return 0;
+    return maxDamage - std::clamp(damage, 0, maxDamage);
+}
+
+inline std::string durabilityText(int damage, int maxDamage) {
+    if (maxDamage <= 0) return {}; // empty / non-damageable equipment has no label
+    return std::to_string(remainingDurability(damage, maxDamage)) + "/" + std::to_string(maxDamage);
+}
+
+inline float durabilityRatio(int damage, int maxDamage) {
+    if (maxDamage <= 0) return 1.0f;
+    return static_cast<float>(remainingDurability(damage, maxDamage)) / static_cast<float>(maxDamage);
+}
+
+inline DurabilityBar durabilityBar(const SlotRect& slot, float remainingRatio) {
+    const float ratio = std::clamp(remainingRatio, 0.0f, 1.0f);
+    const float unit = slot.size / 16.0f;
+    DurabilityBar bar;
+    bar.x = slot.x + 2.0f * unit;
+    bar.y = slot.y + 13.0f * unit;
+    bar.width = 13.0f * unit;
+    bar.height = std::max(1.0f, 2.0f * unit);
+    bar.fillWidth = bar.width * ratio;
+    bar.fillHeight = std::max(1.0f, unit);
+    return bar;
+}
+
+// Green at full durability fading to red when almost broken (ARGB).
+inline std::uint32_t durabilityColor(float remainingRatio) {
+    const float ratio = std::clamp(remainingRatio, 0.0f, 1.0f);
+    const auto red = static_cast<std::uint32_t>((1.0f - ratio) * 255.0f + 0.5f);
+    const auto green = static_cast<std::uint32_t>(ratio * 255.0f + 0.5f);
+    return 0xFF000000u | (red << 16) | (green << 8);
+}
+
+// Baseline anchor of the right-aligned stack count in a slot's bottom-right
+// corner.
+struct TextAnchor {
+    float x = 0.0f;
+    float y = 0.0f;
+};
+
+inline TextAnchor countTextAnchor(const SlotRect& slot) {
+    const float unit = slot.size / 16.0f;
+    TextAnchor anchor;
+    anchor.x = slot.x + slot.size - unit;
+    anchor.y = slot.y + slot.size - unit;
+    return anchor;
+}
+
+} // namespace bedrocktools::slotdecor


### PR DESCRIPTION
Shows the 27 slots of the player's main inventory grid (container slots 9-35, the 9x3 layout of the inventory screen) as item icons on the HUD without opening the inventory.

- Grid: column count (1-27, default 9), slot size, gap between slots.
- Slot details: stack counts with size/color, vanilla-proportioned durability bars, slot background cells (color + opacity) behind empty and filled slots alike.
- Hides automatically while the inventory or any container screen is open, via the ScreenStateEvent container-depth counter.
- Keybind, persistent config, and a single HUD Editor element ("Inventory Grid") with grid/element/screen-center snapping.
- Icons are painted with the game's own ItemRenderer from a shared HudCameraRenderer hook (huditems.hpp/cpp) that also carries the dyed-leather HUD-opacity fix pass; counts and bars go through the launcher's overlay draw commands like the other HUD modules.
- Additive module: the existing ArmorHUD module is untouched.